### PR TITLE
add https identifier to oai_dc format

### DIFF
--- a/oaipmh/templates/record_formats.xml
+++ b/oaipmh/templates/record_formats.xml
@@ -42,6 +42,7 @@
             <dc:date>{{record.current_version_date.strftime('%Y-%m-%d')}}</dc:date>
         {% endif %}
         <dc:type>text</dc:type>
+        <dc:identifier>https://arxiv.org/abs/{{record.current_meta.paper_id}}</dc:identifier>
         <dc:identifier>http://arxiv.org/abs/{{record.current_meta.paper_id}}</dc:identifier>
         {% if record.current_meta.journal_ref %}
             <dc:identifier>{{record.current_meta.journal_ref}}</dc:identifier>

--- a/tests/test_record_format.py
+++ b/tests/test_record_format.py
@@ -27,7 +27,8 @@ def test_oai_dc_format(test_client):
     assert '<dc:description>15 pages. This version corrects some misprints of the published version</dc:description>' in text
     assert '<dc:date>2008-06-25</dc:date>' in text #initial publish day
     assert '<dc:date>2014-12-12</dc:date>' in text #publish date of latest version
-    assert '<dc:type>text</dc:type>' in text #we are alwasy text
+    assert '<dc:type>text</dc:type>' in text #we are always text
+    assert '<dc:identifier>https://arxiv.org/abs/0806.4129</dc:identifier>' in text
     assert '<dc:identifier>http://arxiv.org/abs/0806.4129</dc:identifier>' in text
     assert '<dc:identifier>AIP Conf.Proc.1316:466-477,2010</dc:identifier>' in text
     assert '<dc:identifier>doi:10.1063/1.3536454</dc:identifier>' in text


### PR DESCRIPTION
now looks like
<dc:identifier>https://arxiv.org/abs/adap-org/9711001</dc:identifier>
<dc:identifier>http://arxiv.org/abs/adap-org/9711001</dc:identifier>
<dc:identifier>T. Baeck (Ed.) (1997) Proceedings of the Seventh International Conference on Genetic Algorithms (ICGA'97), Morgan Kauffman, 73-80</dc:identifier>